### PR TITLE
Fix player sinking and relative rotation (#798)

### DIFF
--- a/NitroxClient/GameLogic/MovementHelper.cs
+++ b/NitroxClient/GameLogic/MovementHelper.cs
@@ -43,11 +43,9 @@ namespace NitroxClient.GameLogic
                 // This should be a one-off teleport.
                 gameObject.transform.position = remotePosition;
             }
-            // overcorrections can cause jitter when standing still.
-            else if (distance > 0.001f)
+            else
             {
-                float maxAdjustment = (float)Math.Log10(distance) * 4f;
-                remoteVelocity += MathUtil.ClampMagnitude(velocityToMakeUpDifference - remoteVelocity, maxAdjustment, -maxAdjustment);
+                remoteVelocity = velocityToMakeUpDifference;
             }
 
             return remoteVelocity;

--- a/NitroxClient/GameLogic/RemotePlayer.cs
+++ b/NitroxClient/GameLogic/RemotePlayer.cs
@@ -93,13 +93,13 @@ namespace NitroxClient.GameLogic
             SetVehicle(null);
             SetPilotingChair(null);
             // If in a subroot the position will be relative to the subroot
-            if (SubRoot  != null && !SubRoot.isBase)
+            if (SubRoot != null && !SubRoot.isBase)
             {
                 Quaternion vehicleAngle = SubRoot.transform.rotation;
                 position = vehicleAngle * position;
                 position = position + SubRoot.transform.position;
-                
-                
+                bodyRotation = vehicleAngle * bodyRotation;
+                aimingRotation = vehicleAngle * aimingRotation;
             }
             RigidBody.velocity = AnimationController.Velocity = MovementHelper.GetCorrectedVelocity(position, velocity, Body, PlayerMovement.BROADCAST_INTERVAL);
             RigidBody.angularVelocity = MovementHelper.GetCorrectedAngularVelocity(bodyRotation, Vector3.zero, Body, PlayerMovement.BROADCAST_INTERVAL);
@@ -226,7 +226,7 @@ namespace NitroxClient.GameLogic
         private void UpdateEquipmentVisibility()
         {
             ReadOnlyCollection<TechType> currentEquipment = new ReadOnlyCollection<TechType>(equipment.ToList());
-            
+
             playerModelManager.UpdateEquipmentVisibility(PlayerModel, currentEquipment);
         }
     }

--- a/NitroxClient/MonoBehaviours/PlayerMovement.cs
+++ b/NitroxClient/MonoBehaviours/PlayerMovement.cs
@@ -1,13 +1,11 @@
 ﻿using NitroxClient.GameLogic;
-using NitroxClient.GameLogic.Helper;
 using NitroxModel.Core;
+using NitroxModel.DataStructures;
 using NitroxModel.DataStructures.GameLogic;
 using NitroxModel.DataStructures.Util;
 using NitroxModel.Helper;
 using NitroxModel_Subnautica.Helper;
-using NitroxModel.Logger;
 using UnityEngine;
-using NitroxModel.DataStructures;
 
 namespace NitroxClient.MonoBehaviours
 {
@@ -45,12 +43,13 @@ namespace NitroxClient.MonoBehaviours
                 SubRoot subRoot = Player.main.GetCurrentSub();
                 // If in a subroot the position will be relative to the subroot
                 if (subRoot != null && !subRoot.isBase)
-                { 
+                {
                     // Rotate relative player position relative to the subroot (else there are problems with respawning)
-                    Quaternion vehicleAngle = subRoot.transform.rotation;                    
+                    Quaternion undoVehicleAngle = subRoot.transform.rotation.GetInverse();
                     currentPosition = currentPosition - subRoot.transform.position;
-                    currentPosition = vehicleAngle.GetInverse() * currentPosition;
-
+                    currentPosition = undoVehicleAngle * currentPosition;
+                    bodyRotation = undoVehicleAngle * bodyRotation;
+                    aimingRotation = undoVehicleAngle * aimingRotation;
                 }
 
                 localPlayer.UpdateLocation(currentPosition, playerVelocity, bodyRotation, aimingRotation, vehicle);
@@ -138,16 +137,16 @@ namespace NitroxClient.MonoBehaviours
                 return Optional<VehicleMovementData>.Empty();
             }
 
-            VehicleMovementData model = VehicleMovementFactory.GetVehicleMovementData(  techType, 
-                                                                                        id, 
-                                                                                        position, 
-                                                                                        rotation, 
-                                                                                        velocity, 
-                                                                                        angularVelocity, 
-                                                                                        steeringWheelYaw, 
-                                                                                        steeringWheelPitch, 
-                                                                                        appliedThrottle, 
-                                                                                        leftArmPosition, 
+            VehicleMovementData model = VehicleMovementFactory.GetVehicleMovementData(techType,
+                                                                                        id,
+                                                                                        position,
+                                                                                        rotation,
+                                                                                        velocity,
+                                                                                        angularVelocity,
+                                                                                        steeringWheelYaw,
+                                                                                        steeringWheelPitch,
+                                                                                        appliedThrottle,
+                                                                                        leftArmPosition,
                                                                                         rightArmPosition);
             return Optional<VehicleMovementData>.Of(model);
         }


### PR DESCRIPTION
* PlayerMovement: Rotate body relative to subroot.

This prevents rotation "desync" issues because player positioning is
updated independently from subroot positioning (which can be simulated
or piloted by another player, while this player is freely moving through
the interior).

* MovementHelper: Remove incorrect "smoothing" to address offset issues.

Using a logarithm to "smooth" velocity isn't the right way as can be
seen from the RemotePlayer being offset, most notably in the Y-axis.

Besides, this smoothing should only be applied over time to account for
packet delay.